### PR TITLE
fix: ユニットテストのモック実装を改善 (#30)

### DIFF
--- a/packages/core/src/workflows/a-2.analyze-issue-impact/analyze-issue-impact.test.ts
+++ b/packages/core/src/workflows/a-2.analyze-issue-impact/analyze-issue-impact.test.ts
@@ -13,11 +13,10 @@ describe('AnalyzeIssueImpact Workflow (A-2)', () => {
   // テスト用ユーティリティ: createDriverのモックを設定
   const setupDriverMocks = (analyzeIssueResponse: any) => {
     // 1つのドライバーインスタンスで1つの応答を返す（updatedStateは分析結果に含まれる）
-    mockContext.createDriver = vi.fn().mockResolvedValue(
+    mockContext.createDriver = async () =>
       new TestDriver({
         responses: [JSON.stringify(analyzeIssueResponse)],
-      })
-    );
+      });
   };
 
   const mockIssue: Issue = {

--- a/packages/core/src/workflows/test-utils.ts
+++ b/packages/core/src/workflows/test-utils.ts
@@ -165,46 +165,59 @@ export function createCustomMockContext(overrides?: {
  * よく使うモックIssueを生成
  */
 export function createMockIssue(overrides?: Partial<Issue>): Issue {
+  const baseIssue: Issue = {
+    id: 'issue-test-123',
+    title: 'Test Issue',
+    description: 'Test Description',
+    status: 'open',
+    labels: [],
+    sourceInputIds: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    updates: [],
+    relations: [],
+    // priorityはオプショナルなので設定しない
+  };
+
   return {
-    id: overrides?.id || 'issue-test-123',
-    title: overrides?.title || 'Test Issue',
-    description: overrides?.description || 'Test Description',
-    status: overrides?.status || 'open',
-    labels: overrides?.labels || [],
-    priority: overrides?.priority || 50,
-    sourceInputIds: overrides?.sourceInputIds || [],
-    createdAt: overrides?.createdAt || new Date(),
-    updatedAt: overrides?.updatedAt || new Date(),
-    updates: overrides?.updates || [],
-    relations: overrides?.relations || [],
+    ...baseIssue,
     ...overrides,
-  } as Issue;
+  };
 }
 
 /**
  * よく使うモックKnowledgeを生成
  */
 export function createMockKnowledge(overrides?: Partial<Knowledge>): Knowledge {
+  const baseKnowledge: Knowledge = {
+    id: 'knowledge-test-123',
+    type: 'factoid',
+    content: 'Test Knowledge Content',
+    reputation: { upvotes: 0, downvotes: 0 },
+    sources: [],
+    createdAt: new Date(),
+  };
+
   return {
-    id: overrides?.id || 'knowledge-test-123',
-    type: overrides?.type || 'factoid',
-    content: overrides?.content || 'Test Knowledge Content',
-    reputation: overrides?.reputation || { upvotes: 0, downvotes: 0 },
-    sources: overrides?.sources || [],
-    createdAt: overrides?.createdAt || new Date(),
-  } as Knowledge;
+    ...baseKnowledge,
+    ...overrides,
+  };
 }
 
 /**
  * よく使うモックPondEntryを生成
  */
 export function createMockPondEntry(overrides?: Partial<PondEntry>): PondEntry {
+  const basePondEntry: PondEntry = {
+    id: 'pond-test-123',
+    content: 'Test Pond Content',
+    source: 'test',
+    timestamp: new Date(),
+    // metadata, context, vector, score, distanceはオプショナルなので設定しない
+  };
+
   return {
-    id: overrides?.id || 'pond-test-123',
-    content: overrides?.content || 'Test Pond Content',
-    source: overrides?.source || 'test',
-    timestamp: overrides?.timestamp || new Date(),
-    metadata: overrides?.metadata || {},
+    ...basePondEntry,
     ...overrides,
-  } as PondEntry;
+  };
 }


### PR DESCRIPTION
## 概要
Issue #30の修正として、ユニットテストのモック実装を改善しました。

## 関連Issue
Closes #30

## 変更内容

### 1. TestDriverの二重モック問題を修正
- `vi.fn().mockResolvedValue(new TestDriver(...))`という誤った使い方を修正
- 正しいDriverFactoryパターンに変更: `async () => new TestDriver(...)`

### 2. test-utils.tsの型キャスト問題を修正
- `as Issue`, `as Knowledge`, `as PondEntry`のキャストを削除
- 型安全な実装に変更（constで型を明示的に定義）
- オプショナルなフィールドはコメントで明記

## テスト結果
✅ 全ユニットテスト成功（79 tests passed）
✅ 型チェック成功
✅ リント成功

これにより、実装との型の整合性が保証され、TypeScriptの型推論が正しく機能するように改善されました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)